### PR TITLE
fix[Chat_room]:QUIT指令帶參數BUG

### DIFF
--- a/Chat_room.py
+++ b/Chat_room.py
@@ -26,7 +26,7 @@ class sendThread(threading.Thread):
             msg = input()
             self.sock.sendall(msg.encode('UTF-8'))
             args = msg.split()
-            if len(args)==1 and args[0].upper()=="/QUIT":
+            if args[0].lower()=="/quit" and len(args)==1:
                 break
             
 class serverThread(threading.Thread):
@@ -49,7 +49,7 @@ class serverThread(threading.Thread):
                                 self.sock.sendall(msg.encode('UTF-8'))
                         else:
                             self.sock.sendall(b"No user is online")
-                    elif args[0].lower()=="/quit":
+                    elif args[0].lower()=="/quit" and len(args)==1:
                         self.userQuit()
                         break
                     else:


### PR DESCRIPTION
問題:
QUIT指令後面有參數時，會導致client的sendThread進入無窮迴圈

原因:
沒有檢查QUIT參數數量

調整項目:
指令為QUIT且不帶參數才執行userQuit()

Closes #11